### PR TITLE
feat: enable DockerHub login by default in CI job template

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ After that, in Azure DevOps a new pipeline has to be created from this file.
 | lockImages | Specify whether an image built based on a Git tag should be locked in the Azure container registry. | true | Yes |
 | jobTimeoutInMinutes | Specifies the maximum job execution time in minutes. | 300 | Yes |
 | jobContinueOnError | Specifies whether future jobs should run even if this job fails | false | Yes |
-| dockerhubLogin | Specifies whether to perform a DockerHub login before the build steps. | false |  |
+| dockerhubLogin | Specifies whether to perform a DockerHub login before the build steps. | true |  |
 | dockerhubServiceConnection | Name of the DockerHub registry service connection to use for login. | '$(DOCKERHUB_PUBLIC_SERVICE_CONNECTION)' | Only when `dockerhubLogin` is true |
 
 ## Important information:

--- a/ci-job-template.yml
+++ b/ci-job-template.yml
@@ -135,7 +135,7 @@ parameters:
   # Specifies whether to perform a DockerHub login before the build steps.
 - name: dockerhubLogin
   type: boolean
-  default: false
+  default: true
 
   # Name of the DockerHub registry service connection to use for login.
 - name: dockerhubServiceConnection


### PR DESCRIPTION
- The `dockerhubLogin` parameter is set to true by default. This is mandatory because some builds hit the Docker Hub pull rate limit.
